### PR TITLE
sprint4 memleak upload fixes

### DIFF
--- a/Roadmap/ROADMAP.md
+++ b/Roadmap/ROADMAP.md
@@ -175,7 +175,7 @@
 - [x] **Issue #54**: Performance Optimization (3 hours) - ✅ **COMPLETED**
 - [x] **Issue #55**: Prepare Release v0.2.0 (2 hours) - ✅ **COMPLETED**
 
-### 10. Sprint 4: Advanced Features & Production Deployment (0% complete) - 6 days
+### 10. Sprint 4: Advanced Features & Production Deployment (progressing) - 6 days
 
 **Status**: 🚀 **ACTIVE** - In Progress
 
@@ -183,6 +183,17 @@
 - **Issue #56**: Fix CreateContainer Implementation (16 hours) - 🚀 **ACTIVE**
 - **Issue #57**: CRI Integration & Runtime Selection (16 hours) - 🚀 **ACTIVE**
 - **Issue #58**: OCI Bundle Generation & Configuration (16 hours) - 🚀 **ACTIVE**
+
+**Recent Sprint 4 updates (2025-09-24)**:
+- Fixed memory cleanup paths:
+  - `Client.deinit()` frees `hosts`, `token`, `base_urls`
+  - Avoid double-free in `ProxmoxClient.deinit`
+  - Proper `deinit()` in `ImageManager` and `LXCManager`
+  - Adjusted cleanup for `proxmox_client` in `main.zig`
+- Multipart upload fixes for Proxmox template:
+  - Corrected `Content-Type` handling and multipart boundaries
+  - File data sent in `content` field with `filename`
+- Build and remote compile are green; remaining runtime GPA leaks on upload under investigation
 
 **Goals**:
 - Fix CreateContainer command according to technical requirements

--- a/Roadmap/sprint4/32-memleak-and-upload-fixes.md
+++ b/Roadmap/sprint4/32-memleak-and-upload-fixes.md
@@ -1,0 +1,31 @@
+# Sprint 4 — Memory leaks & Proxmox upload fixes
+
+Date: 2025-09-24
+
+## Scope
+- Fix memory leaks and lifetime issues in managers and client code
+- Stabilize multipart upload to Proxmox (template upload)
+- Ensure build is green and remote testing passes compilation stage
+
+## Changes
+- proxmox/client.zig: add proper cleanup in `Client.deinit()` for `hosts`, `token`, `base_urls`
+- proxmox/proxmox.zig: avoid double-free; rely on `Client.deinit()`; adjust `deinit`
+- oci/image/manager.zig: free/destroy `LayerFS`, `MetadataCache`, `LayerManager`, `file_ops`, `self` in `deinit`
+- oci/lxc.zig: destroy `self` in `deinit`
+- main.zig: add consistent cleanup path for `proxmox_client`; fix `defer` placement to avoid syntax issues
+- proxmox/client.zig: remove unsupported `request.timeout`; keep retry handling for `ConnectionResetByPeer`; correct multipart `Content-Type`
+- proxmox/template/operations.zig: correct multipart form structure — send file under `content` with filename
+
+## Results
+- Local build: OK (`zig build` succeeds)
+- Remote compile: OK (build succeeds), runtime still shows remaining GPA leak traces during large upload — further iteration planned
+
+## Next Steps
+- Finalize Proxmox template upload resilience (retries/backoff and stream write buffering)
+- Validate LXC create path via Proxmox API end-to-end; ensure `rootfs_path` passed and containerd fallback logic is effective
+- Track and close remaining GPA leaks reported during remote run
+
+## Time Spent
+- Implementation & testing: 1h 10m
+
+

--- a/src/common/config.zig
+++ b/src/common/config.zig
@@ -52,6 +52,7 @@ pub const Config = struct {
     allocator: std.mem.Allocator,
     runtime_type: RuntimeType,
     runtime_path: ?[]const u8,
+    default_runtime: ?[]const u8,
     proxmox: ProxmoxConfig,
     storage: StorageConfig,
     network: NetworkConfig,
@@ -77,6 +78,7 @@ pub const Config = struct {
             .allocator = allocator,
             .runtime_type = .runc,
             .runtime_path = null,
+            .default_runtime = null,
             .proxmox = try ProxmoxConfig.init(allocator),
             .storage = try StorageConfig.init(allocator),
             .network = try NetworkConfig.init(allocator),
@@ -95,6 +97,9 @@ pub const Config = struct {
     pub fn deinit(self: *Config) void {
         if (self.runtime_path) |path| {
             self.allocator.free(path);
+        }
+        if (self.default_runtime) |rt| {
+            self.allocator.free(rt);
         }
         self.proxmox.deinit();
         self.storage.deinit();
@@ -126,6 +131,11 @@ pub const Config = struct {
         // if (runtime.log_level) |level| {
         //     ...
         // }
+    }
+
+    // Default runtime from root json
+    if (json_config.default_runtime) |rt| {
+        config.default_runtime = try allocator.dupe(u8, rt);
     }
 
     // Proxmox config

--- a/src/common/types.zig
+++ b/src/common/types.zig
@@ -859,6 +859,7 @@ pub const JsonConfig = struct {
     proxmox: ?ProxmoxConfig = null,
     storage: ?StorageConfig = null,
     network: ?NetworkConfig = null,
+    default_runtime: ?[]const u8 = null,
 };
 
 pub const StorageConfig = struct {

--- a/src/main.zig
+++ b/src/main.zig
@@ -975,6 +975,7 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
+    
     // Parse command line arguments
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
@@ -1029,7 +1030,9 @@ pub fn main() !void {
             node, 
             &temp_logger
         );
+        
     }
+    
     
     // Create temporary logger for command execution
     var main_logger = try logger_mod.Logger.init(allocator, std.io.getStdErr().writer(), .info, "main");
@@ -1137,6 +1140,12 @@ pub fn main() !void {
         else => {
             try std.io.getStdErr().writer().writeAll("Command not implemented in this test version\n");
         },
+    }
+    
+    // Cleanup proxmox_client at the end
+    if (proxmox_client) |pc| {
+        pc.deinit();
+        allocator.destroy(pc);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -975,6 +975,14 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
+    defer {
+        // Ensure global proxmox_client is cleaned on any exit path
+        if (proxmox_client) |pc| {
+            pc.deinit();
+            allocator.destroy(pc);
+            proxmox_client = null;
+        }
+    }
     
     // Parse command line arguments
     const args = try std.process.argsAlloc(allocator);

--- a/src/oci/image/manager.zig
+++ b/src/oci/image/manager.zig
@@ -81,10 +81,14 @@ pub const ImageManager = struct {
         // Clean up new OCI image system components
         if (self.layer_fs) |layerfs| {
             layerfs.deinit();
+            self.allocator.destroy(layerfs);
         }
         self.metadata_cache.deinit();
+        self.allocator.destroy(self.metadata_cache);
         self.layer_manager.deinit();
+        self.allocator.destroy(self.layer_manager);
         // file_ops doesn't have deinit method
+        self.allocator.destroy(self.file_ops);
         
         self.allocator.destroy(self);
     }

--- a/src/oci/image/manager.zig
+++ b/src/oci/image/manager.zig
@@ -80,8 +80,8 @@ pub const ImageManager = struct {
         
         // Clean up new OCI image system components
         if (self.layer_fs) |layerfs| {
+            // layerfs.deinit() already calls allocator.destroy(self)
             layerfs.deinit();
-            self.allocator.destroy(layerfs);
         }
         self.metadata_cache.deinit();
         self.allocator.destroy(self.metadata_cache);

--- a/src/oci/lxc.zig
+++ b/src/oci/lxc.zig
@@ -19,8 +19,7 @@ pub const LXCManager = struct {
     }
 
     pub fn deinit(self: *@This()) void {
-        _ = self;
-        // TODO: Implement LXC cleanup
+        self.allocator.destroy(self);
     }
 
     pub fn containerExists(self: *@This(), id: []const u8) !bool {

--- a/src/proxmox/client.zig
+++ b/src/proxmox/client.zig
@@ -127,8 +127,8 @@ pub const Client = struct {
             const headers = [_]http.Header{
                 .{ .name = "Authorization", .value = auth_header },
                 .{ .name = "Content-Type", .value = "application/json" },
-                .{ .name = "Expect", .value = "100-continue" },
                 .{ .name = "Accept", .value = "application/json" },
+                .{ .name = "Connection", .value = "close" },
             };
             request.extra_headers = &headers;
 
@@ -224,15 +224,14 @@ pub const Client = struct {
             const headers = [_]http.Header{
                 .{ .name = "Authorization", .value = auth_header },
                 .{ .name = "Content-Type", .value = content_type_value },
-                .{ .name = "Expect", .value = "100-continue" },
                 .{ .name = "Accept", .value = "application/json" },
+                .{ .name = "Connection", .value = "close" },
             };
             request.extra_headers = &headers;
 
             if (body) |b| {
-                // Use chunked encoding for large multipart to avoid full content-length buffering
-                _ = b; // unused for length
-                request.transfer_encoding = .chunked;
+                // Use Content-Length for multipart uploads
+                request.transfer_encoding = .{ .content_length = b.len };
             }
 
             request.send() catch |err| {

--- a/src/proxmox/client.zig
+++ b/src/proxmox/client.zig
@@ -127,6 +127,7 @@ pub const Client = struct {
             const headers = [_]http.Header{
                 .{ .name = "Authorization", .value = auth_header },
                 .{ .name = "Content-Type", .value = "application/json" },
+                .{ .name = "Expect", .value = "100-continue" },
             };
             request.extra_headers = &headers;
 
@@ -145,7 +146,7 @@ pub const Client = struct {
             };
             if (body) |b| {
                 // Write request body in small chunks to reduce risk of TLS resets
-                const chunk_size: usize = 64 * 1024;
+                const chunk_size: usize = 16 * 1024;
                 var offset: usize = 0;
                 while (offset < b.len) {
                     const end = @min(offset + chunk_size, b.len);
@@ -221,6 +222,7 @@ pub const Client = struct {
             const headers = [_]http.Header{
                 .{ .name = "Authorization", .value = auth_header },
                 .{ .name = "Content-Type", .value = content_type_value },
+                .{ .name = "Expect", .value = "100-continue" },
             };
             request.extra_headers = &headers;
 
@@ -239,7 +241,7 @@ pub const Client = struct {
             };
             if (body) |b| {
                 // Chunked write to mitigate ConnectionResetByPeer on large bodies
-                const chunk_size: usize = 64 * 1024;
+                const chunk_size: usize = 16 * 1024;
                 var offset: usize = 0;
                 while (offset < b.len) {
                     const end = @min(offset + chunk_size, b.len);

--- a/src/proxmox/proxmox.zig
+++ b/src/proxmox/proxmox.zig
@@ -100,11 +100,9 @@ pub const ProxmoxClient = struct {
 
     pub fn deinit(self: *ProxmoxClient) void {
         self.client.deinit();
-        // host, token, node звільняються в Client.deinit
-        // self.allocator.free(self.host); // звільняється в Client.deinit
-        // self.allocator.free(self.token); // звільняється в Client.deinit  
-        // self.allocator.free(self.node); // звільняється в Client.deinit
-        // self.allocator.free(self.client.hosts); // звільняється в Client.deinit
+        // host і token звільняються в Client.deinit
+        // Звільняємо node, який належить ProxmoxClient
+        if (self.node.len > 0) self.allocator.free(self.node);
     }
 
     pub fn getProxmoxVMID(self: *ProxmoxClient, oci_container_id: []const u8) !u32 {

--- a/src/proxmox/proxmox.zig
+++ b/src/proxmox/proxmox.zig
@@ -100,10 +100,11 @@ pub const ProxmoxClient = struct {
 
     pub fn deinit(self: *ProxmoxClient) void {
         self.client.deinit();
-        self.allocator.free(self.host);
-        self.allocator.free(self.token);
-        self.allocator.free(self.node);
-        self.allocator.free(self.client.hosts);
+        // host, token, node звільняються в Client.deinit
+        // self.allocator.free(self.host); // звільняється в Client.deinit
+        // self.allocator.free(self.token); // звільняється в Client.deinit  
+        // self.allocator.free(self.node); // звільняється в Client.deinit
+        // self.allocator.free(self.client.hosts); // звільняється в Client.deinit
     }
 
     pub fn getProxmoxVMID(self: *ProxmoxClient, oci_container_id: []const u8) !u32 {

--- a/src/proxmox/template/operations.zig
+++ b/src/proxmox/template/operations.zig
@@ -107,14 +107,14 @@ pub fn createTemplateFromRootfs(client: *Client, rootfs_path: []const u8, templa
     const content_type = try fmt.allocPrint(client.allocator, "multipart/form-data; boundary={s}", .{boundary});
     defer client.allocator.free(content_type);
     
-    // Додаємо поле content=vztmpl
+    // Додаємо поле filename
     try form_data.writer().print("--{s}\r\n", .{boundary});
-    try form_data.writer().print("Content-Disposition: form-data; name=\"content\"\r\n\r\n", .{});
-    try form_data.writer().print("vztmpl\r\n", .{});
+    try form_data.writer().print("Content-Disposition: form-data; name=\"filename\"\r\n\r\n", .{});
+    try form_data.writer().print("{s}.tar.zst\r\n", .{template_name});
     
-    // Додаємо файл як поле filename
+    // Додаємо файл як поле content
     try form_data.writer().print("--{s}\r\n", .{boundary});
-    try form_data.writer().print("Content-Disposition: form-data; name=\"filename\"; filename=\"{s}.tar.zst\"\r\n", .{template_name});
+    try form_data.writer().print("Content-Disposition: form-data; name=\"content\"; filename=\"{s}.tar.zst\"\r\n", .{template_name});
     try form_data.writer().print("Content-Type: application/octet-stream\r\n\r\n", .{});
     try form_data.appendSlice(file_content);
     try form_data.writer().print("\r\n--{s}--\r\n", .{boundary});

--- a/src/proxmox/template/operations.zig
+++ b/src/proxmox/template/operations.zig
@@ -133,7 +133,8 @@ pub fn createTemplateFromRootfs(client: *Client, rootfs_path: []const u8, templa
         const filename_arg = try fmt.allocPrint(client.allocator, "filename={s}.tar.zst", .{template_name});
         defer client.allocator.free(filename_arg);
 
-        const content_arg = try fmt.allocPrint(client.allocator, "content=@{s}.tar.zst;type=application/octet-stream", .{template_name});
+        // Використовуємо абсолютний шлях до архіву
+        const content_arg = try fmt.allocPrint(client.allocator, "content=@{s};type=application/octet-stream", .{archive_path});
         defer client.allocator.free(content_arg);
 
         const auth_header_arg = try fmt.allocPrint(client.allocator, "Authorization: PVEAPIToken={s}", .{client.token});


### PR DESCRIPTION
- **Sprint 4: Runtime selection, config default_runtime, LXC create path, multipart upload fixes**
- **Sprint4: fix memory cleanup (Client.deinit hosts/token/base_urls; ImageManager/LXCManager deinit), correct multipart upload for Proxmox templates, remove unsupported request.timeout, add robust cleanup for proxmox_client; update Roadmap**
