### PR TITLE
Sprint 6.4 Closure Report

### DIFF
--- a/Roadmap/SPRINT_6.4_CLOSURE.md
+++ b/Roadmap/SPRINT_6.4_CLOSURE.md
@@ -1,0 +1,39 @@
+# Sprint 6.4 Closure Report
+
+Date: 2025-10-13
+Status: COMPLETED
+Branch merged: feat/optimize-github-actions → main (squash)
+Total time: 5h 30m
+
+Summary
+- CI/CD оптимізовано: multi-runner (proxmox, runner0)
+- Додано crun E2E (create/start/stop/delete)
+- Видалено дублікати/зайві воркфлоу; docs тимчасово вимкнено
+- Оновлено документацію та інструкції для серверних правок
+
+Main CI status after merge
+- CI (CNCF Compliant): success
+- Security: success
+- Proxmox E2E: success
+- crun_e2e: failure (очікувано: потребує донастройки середовища)
+- Dependencies: failure (очікувано: оновлення індексів та кешів на runner)
+
+Local build
+- Command: `zig build -Doptimize=ReleaseSafe`
+- Result: success
+
+Post-merge actions (server mgr.cp.if.ua)
+- Додати користувача `github-runner` до групи `docker`
+- Перезапустити runner-сервіс
+- Після виправлень повторно увімкнути docs workflow
+
+Artifacts
+- MERGE_INSTRUCTIONS.md
+- Roadmap/SPRINT_6.4_FINAL_SUMMARY.md
+- Roadmap/GITHUB_ACTIONS_FIXES_SUMMARY.md
+
+Verification
+- Останні запуски на main: більшість зелені; 2 червоні — очікувані
+
+Prepared by: AI Assistant
+


### PR DESCRIPTION
Adds closure report for Sprint 6.4 after merging PR #107. Includes CI status, local build verification, and post-merge actions.