### PR TITLE
Roadmap: CI post-merge status (2025-10-13)

### DIFF
--- a/Roadmap/CI_POST_MERGE_STATUS_2025-10-13.md
+++ b/Roadmap/CI_POST_MERGE_STATUS_2025-10-13.md
@@ -1,0 +1,26 @@
+CI Post-Merge Status (2025-10-13)
+
+Branch: main
+
+Summary
+- CI (CNCF Compliant): success
+- Security: success
+- Proxmox E2E (Self-Hosted): success
+- crun_e2e: failure (rerun denied: workflow file may be broken)
+- Dependencies: previous failure, pending next trigger
+
+Actions
+- Tried gh workflow run → not allowed (no workflow_dispatch)
+- Tried gh run rerun for crun_e2e → denied
+- Dependencies will retrigger on next commit
+
+Next Steps
+- Add workflow_dispatch to .github/workflows/crun_e2e.yml for manual runs
+- Apply server-side Docker group fix if needed (see PROXMOX_DOCKER_FIX.md)
+- Push a minimal commit to retrigger Dependencies
+
+Local Build
+- zig build -Doptimize=ReleaseSafe: success
+
+Prepared by: AI Assistant
+


### PR DESCRIPTION
Adds CI post-merge status report for 2025-10-13. Includes current state, actions taken, next steps, and local build verification.