### PR TITLE
fix: make the vendored Docker build work from a clean clone

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -78,3 +78,7 @@ TESTING.md
 MERGE_INSTRUCTIONS.md
 CHANGELOG.md
 NOTICE
+
+# gen_crun_headers_local.sh is the only working crun header generator;
+# excluding scripts/ made the vendored build impossible inside the image.
+!scripts/gen_crun_headers_local.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/bfc"]
 	path = deps/bfc
-	url = git@github.com:themoriarti/bfc.git
+	url = https://github.com/themoriarti/bfc.git
 [submodule "deps/crun"]
 	path = deps/crun
 	url = https://github.com/kubebsd/crun.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && apt-get install -y \
     libsystemd-dev \
     # Additional build dependencies for crun
     go-md2man \
-    libprotobuf-c-dev \  # Required by crun for OCI runtime spec serialization
+    # libprotobuf-c-dev: required by crun
+    libprotobuf-c-dev \
     libyajl-dev \
     && rm -rf /var/lib/apt/lists/*
 
@@ -70,8 +71,16 @@ WORKDIR /app
 COPY . .
 
 # Initialize git submodules (bfc and crun)
-RUN git init || true && \
-    git submodule update --init --recursive || true
+# .dockerignore excludes .git and .gitmodules, so submodule commands can
+# never work inside this image — the previous `git init || true && git
+# submodule update` was a no-op that `|| true` made look harmless. Clone the
+# dependencies explicitly at their pinned commits instead.
+RUN git clone https://github.com/themoriarti/bfc.git deps/bfc && \
+    git -C deps/bfc checkout -q 717ec880a0c5a4860e47ee9b2037450642e8f241 && \
+    git clone https://github.com/kubebsd/crun.git deps/crun && \
+    git -C deps/crun checkout -q c1ef7a1ee256236c6d8f41a6c7cda228f8b7bb79 && \
+    git -C deps/crun submodule update --init libocispec && \
+    git -C deps/crun/libocispec submodule update --init runtime-spec image-spec yajl
 
 # Build arguments for customizing build
 ARG BUILD_FLAGS=""
@@ -83,6 +92,18 @@ RUN rm -rf .zig-cache /root/.cache/zig
 
 # Build project with default configuration (all features enabled)
 # Note: libcrun ABI mode is disabled by default, use -Denable-libcrun-abi=true to enable
+# Vendored crun needs two generated header sets, and neither is produced by
+# `zig build`. The Makefile prescribes `zig build prepare-crun`, a step that
+# does not exist in build.zig — this is what actually works.
+RUN bash scripts/gen_crun_headers_local.sh
+
+# ocispec/*.h come from JSON schemas. generate.py is called directly rather
+# than through autogen.sh, which would require libtool for no benefit here.
+RUN mkdir -p deps/crun/libocispec/src/ocispec && \
+    cd deps/crun/libocispec && \
+    python3 src/ocispec/generate.py --gen-ref --root=. --out=src/ocispec runtime-spec/schema && \
+    python3 src/ocispec/generate.py --gen-ref --root=. --out=src/ocispec image-spec/schema
+
 RUN zig build -Doptimize=ReleaseSafe ${BUILD_FLAGS}
 
 # ============================================================================


### PR DESCRIPTION
The Dockerfile could not be built at all — it failed to parse. Fixing that exposed four further problems, each hidden by the one before it.

## What was wrong

| # | Problem | Why it stayed hidden |
|---|---|---|
| 1 | Inline comment after a line continuation in the apt list | `unknown instruction: libyajl-dev` — the file had never been built |
| 2 | `.dockerignore` excludes `.git` and `.gitmodules` | submodule commands inside the image could never do anything |
| 3 | `git submodule update … \|\| true` | turned that impossibility into a silent no-op |
| 4 | `.dockerignore` excludes `scripts` | the only working crun header generator never reached the image |
| 5 | No ocispec header generation at all | vendored crun cannot compile without it |

Problem 3 is the expensive one. The build went on to fail four steps later with `libcrun sources missing`, which points at neither the cause nor the right directory — `gatherLibcrunSources` reads two paths, and the missing one was `libocispec`.

## What this changes

- Dependencies are cloned explicitly at their pinned commits (`bfc@717ec88`, `crun@c1ef7a1`), since submodule machinery cannot work here by construction
- `scripts/gen_crun_headers_local.sh` is un-ignored and run — it works, unlike the documented path
- `ocispec/*.h` are generated by calling `generate.py` directly; going through `autogen.sh` would require libtool for no benefit
- `deps/bfc` moves to HTTPS now that `themoriarti/bfc` is public, so no SSH key is needed

## Verified

Fresh clone, `docker build --no-cache`, then:

```
$ docker run --rm <image> version
nexcage version 0.7.5
```

## Left alone deliberately

README and the Makefile prescribe `make prepare-crun`, which runs `zig build prepare-crun`. That step does not exist in `build.zig` — only `install`, `uninstall`, `run`, `test`. `build_vendored.yml` also passes `-Duse-vendored-libcrun=true`, which is not a declared option.

Both are real, but fixing them is a separate decision about what the documented path should be. This PR only makes a working path exist.